### PR TITLE
Convert secrets to use environment files, and force all external traffic through Traefik

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.env/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,13 +15,8 @@ services:
       - sql_scripts:/docker-entrypoint-initdb.d
       - server_db:/var/lib/mysql
       - ./database/my.cnf:/etc/my.cnf
-    environment: 
-      MYSQL_DATABASE: ragnarok
-      MYSQL_USER: ragnarok
-      MYSQL_PASSWORD: ragnarok
-      MYSQL_ROOT_PASSWORD: secret
-    ports:
-      - 3306:3306
+    env_file: 
+      - .env/production
 
   graphql:
     image: bryanveloso/enyxsis-graphql-server:latest
@@ -30,8 +25,6 @@ services:
       DB_HOST: database
     depends_on:
       - database
-    ports:
-      - 4000:4000
     labels: 
       - "traefik.enable=true"
       - "traefik.http.routers.api.rule=Host(`api.enyxsis.com`)"
@@ -47,6 +40,9 @@ services:
       - database
     ports:
       - 6121:6121
+    labels:
+      - "traefik.enable=true"
+      - "traefik.tcp.routers.char.entrypoints=char"
 
   login:
     image: core
@@ -55,8 +51,9 @@ services:
     depends_on: 
       - core
       - database
-    ports:
-      - 6900:6900
+    labels:
+    - "traefik.enable=true"
+    - "traefik.tcp.routers.login.entrypoints=login"
 
   map:
     image: core
@@ -65,9 +62,10 @@ services:
     depends_on: 
       - core
       - database
-    ports:
-      - 5121:5121
-          
+    labels:
+      - "traefik.enable=true"
+      - "traefik.tcp.routers.map.entrypoints=map"
+
   status:
     build: ./status
     image: status:latest
@@ -79,8 +77,6 @@ services:
       MAP_IP: map
       MAP_PORT: 5121
       PORT: 3000
-    ports:
-      - 3000:3000
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.status.rule=Host(`status.enyxsis.com`)"
@@ -95,9 +91,6 @@ services:
       GIT_NAME: Bryan Veloso
       GIT_REPO: https://github.com/bryanveloso/FluxCP/
       DOMAIN: renova.avalonstar.tv
-    ports:
-      - 8088:80
-      - 8443:443    
     labels: 
       - "traefik.enable=true"
       - "traefik.http.routers.flux.rule=Host(`oldcp.enyxsis.com`)"
@@ -114,6 +107,9 @@ services:
       - 80:80
       - 443:443
       - 8080:8080
+      - 6121:6121
+      - 6900:6900
+
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.http_catchall.rule=HostRegexp(`{any:.+}`)"

--- a/traefik/traefik.yml
+++ b/traefik/traefik.yml
@@ -8,6 +8,12 @@ entryPoints:
     address: ":80"
   secure:
     address: ":443"
+  login:
+    address: ":6900"
+  map: 
+    address: ":5121"
+  char:
+    address: ":6121"
 providers:
   docker:
     endpoint: "unix:///var/run/docker.sock"


### PR DESCRIPTION
This PR:

* Sets up for the use of environment files for MySQL secrets
* Disables direct network access for all services 
* Sets up Traefik TCP routers to shunt all traffic for any public service (login, character, map)